### PR TITLE
Use async bcrypt compare and test password verification

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -108,7 +108,7 @@ class User {
     }
 
     static async verifyPassword(plainPassword, hashedPassword) {
-        return bcrypt.compare(plainPassword, hashedPassword);
+        return await bcrypt.compare(plainPassword, hashedPassword);
     }
 
     static async changePassword(id, oldPassword, newPassword) {

--- a/test-models.js
+++ b/test-models.js
@@ -34,6 +34,10 @@ async function testModels() {
             console.log('✅ Usuario admin ya existe:', adminUser.username);
         }
 
+        // Verificar contraseña del usuario admin con bcrypt async
+        const adminPasswordValid = await User.verifyPassword('123456', adminUser.password);
+        console.log('🔐 Verificación contraseña admin:', adminPasswordValid);
+
         // Verificar si el usuario cajero ya existe
         let cajeroUser = await User.findByUsername('cajero');
         


### PR DESCRIPTION
## Summary
- ensure password verification awaits async bcrypt.compare
- exercise bcrypt password verification in model tests

## Testing
- `npm test` *(fails: JWT_SECRET must be set in environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3d41766c832cb23467dcfd1d73a6