### PR TITLE
refactor: separate app configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Sistema de Punto de Venta completo",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
+    "start": "node ./server.js",
+    "dev": "nodemon ./server.js",
     "test": "node test-models.js && node test-api.js",
     "test-models": "node test-models.js",
     "test-api": "node test-api.js",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const app = require('./server/app');
-const config = require('./server/config/config');
 
-const PORT = config.PORT;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`🚀 Servidor POS iniciado en http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- simplify server.js to only require the app and listen on a port
- point package scripts at the root server.js entry

## Testing
- `JWT_SECRET=testsecret npm test` *(fails: Servidor no está funcionando)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3d4e4f6c832c88b3784daeaf07df