### PR TITLE
Enable content security policy in production

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,7 +10,23 @@ require('./config/database');
 
 const app = express();
 
-app.use(helmet({ contentSecurityPolicy: config.ENVIRONMENT === 'production' ? undefined : false }));
+if (config.ENVIRONMENT === 'production') {
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'", "'unsafe-inline'"],
+          styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+          imgSrc: ["'self'", 'data:', 'blob:', 'https:'],
+          fontSrc: ["'self'", 'https://fonts.gstatic.com']
+        }
+      }
+    })
+  );
+} else {
+  app.use(helmet({ contentSecurityPolicy: false }));
+}
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,


### PR DESCRIPTION
## Summary
- Enable Helmet's contentSecurityPolicy only in production
- Specify script, style, image and font directives aligned with served resources

## Testing
- `JWT_SECRET=test npm test` *(fails: Error: server is not functioning, GET /api/test 404)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3d54bae0832cb4b6469de765b73e